### PR TITLE
Townsville City Council - change from early_release to heroku-18 platform and patch missing php library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,22 @@
 # Ignore output of scraper
 data.sqlite
 vendor/*
+
+# Dev tools
+/.aider*
+/.idea
+/.vscode
+
+# python env
+/venv
+.venv
+
+# Temp and log
+
+!/tmp/.keep
+/log
+!/log/.keep
+
+# Used by direnv and dotenv library to load environment variables.
+.env*
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## 27 Jan 2025 - Ian Heggie
+
+* Manually replaced missing package https://github.com/monkeysuffrage/phpuri.git
+  with https://github.com/XSIRIX/phpuri.git

--- a/composer.lock
+++ b/composer.lock
@@ -96,13 +96,13 @@
             "version": "1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/monkeysuffrage/phpuri.git",
-                "reference": "ad0a5ec033fe616cfef55578b9c7f2458be8fbfc"
+                "url": "https://github.com/XSIRIX/phpuri.git",
+                "reference": "9a27a7910eb07a11fb848c7e6c6d6dfc887995e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/monkeysuffrage/phpuri/zipball/ad0a5ec033fe616cfef55578b9c7f2458be8fbfc",
-                "reference": "ad0a5ec033fe616cfef55578b9c7f2458be8fbfc",
+                "url": "https://github.com/XSIRIX/phpuri/archive/refs/tags/v1.0.0.zip",
+                "reference": "9a27a7910eb07a11fb848c7e6c6d6dfc887995e4",
                 "shasum": ""
             },
             "type": "project",

--- a/platform
+++ b/platform
@@ -1,1 +1,1 @@
-early_release
+heroku-18


### PR DESCRIPTION
* change from early_release to heroku-18 platform 
* patch missing php library
* Update .gitignore for IDE and other temp files

Fixes https://github.com/planningalerts-scrapers/issues/issues/989.

See also:
- https://github.com/planningalerts-scrapers/issues/issues/57